### PR TITLE
fix: add dist folder to list of packaged files

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -139,6 +139,7 @@ pipeline {
       steps {
         sh 'mkdir -p .npm'
         sh 'npm install'
+        sh 'npm run build'
         sh 'npm run release'
       }
     }

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   ],
   "files": [
     "src",
+    "dist",
     "README.md",
     "LICENSE"
   ],


### PR DESCRIPTION
Need to add the dist folder to the list of folders that will get
packaged along with ts compiling.

Semver: patch