### PR TITLE
fix: Localstorage quota limit and less chatty when network error

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -24,6 +24,7 @@ export type LoggerOptionsT = {
   hostname: string;
   flushInterval?: number;
   tags: string;
+  log: Function;
 };
 export type LogDNALogLine = {
   line: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -82,12 +82,11 @@ class LogDNABrowserLogger implements ILogDNABrowserLogger {
       url: this.options.url,
       flushInterval: this.options.flushInterval,
       tags: utils.parseTags(this.options.tags),
+      log: this.error,
     });
-
+    utils.addDebugInfo(this.options, this.context, this.plugins);
     this.registerDefaultPlugins();
     this.registerPlugins(this.options.plugins);
-
-    utils.addDebugInfo(this.options, this.context, this.plugins);
 
     document.addEventListener('visibilitychange', async () => {
       if (document.visibilityState === 'hidden') {

--- a/src/offline-storage.ts
+++ b/src/offline-storage.ts
@@ -27,7 +27,11 @@ class OfflineStorage {
       return;
     }
     const stored = this.getLines();
-    window.localStorage.setItem(key, JSON.stringify(stored.concat(lines)));
+    try {
+      window.localStorage.setItem(key, JSON.stringify(stored.concat(lines)));
+    } catch (error) {
+      // This is to catch quota errors but we dont want to log them.
+    }
   }
 
   clear() {

--- a/src/plugins/console.ts
+++ b/src/plugins/console.ts
@@ -40,6 +40,9 @@ class ConsolePlugin implements Plugin {
     const { log, debug, error, warn, info, assert } = window.console;
     const _windowConsole = { log, debug, error, warn, info, assert };
 
+    //@ts-ignore
+    window.__LogDNA__.console = _windowConsole;
+
     (integrations || [])
       .map((method: LogType): LogType => method.toLowerCase() as LogType)
       .forEach((method: LogType) => {

--- a/tests/plugins/console.spec.ts
+++ b/tests/plugins/console.spec.ts
@@ -1,5 +1,8 @@
 import Console, { DEFAULT_CONSOLE_METHODS } from '../../src/plugins/console';
 
+//@ts-ignore
+window.__LogDNA__ = {};
+
 describe('Console Plugin', () => {
   let logdna: any;
 


### PR DESCRIPTION
Summary:
Previously localstorage could fill up if there was a network errors,
now they are caught.  Also we were throwing http error when they should have
been logged via the browser logger to LogDNA.  Also we are no longer sending CORS
errors, misconfigured key, whitelisting issues or other network
errors to localstorage or to logdna.  They are only sent to console.error

Semver: patch