### PR TITLE
fix(types): Add types to BeforeSendHook

### DIFF
--- a/src/capture.ts
+++ b/src/capture.ts
@@ -15,7 +15,7 @@ const captureMessage = ({ level = 'log', message, lineContext = {} }: LogMessage
   }
 
   // run the beforeSend hooks
-  const data: LogMessage = (getOptions().hooks || { beforeSend: [] }).beforeSend.reduce((acc, fn) => (acc == null ? null : fn(acc)), {
+  const data: LogMessage = (getOptions().hooks || { beforeSend: [] }).beforeSend.reduce((acc: LogMessage, fn: Function) => (acc == null ? null : fn(acc)), {
     level,
     message,
     lineContext,

--- a/src/logdna.d.ts
+++ b/src/logdna.d.ts
@@ -85,7 +85,8 @@ export type Plugin = {
 type Hooks = {
   beforeSend: BeforeSendHook;
 };
-type BeforeSendHook = Function;
+
+type BeforeSendHook = (logMessage: LogMessage) => LogMessage;
 
 type HooksOption = {
   beforeSend: BeforeSendHook[];

--- a/src/plugin-manager.ts
+++ b/src/plugin-manager.ts
@@ -50,6 +50,10 @@ export const initPlugins = (options: LogDNABrowserOptions) => {
     if (p.hooks && options.hooks) {
       if (utils.isFunction(p.hooks.beforeSend)) {
         options.hooks.beforeSend.push(p.hooks.beforeSend);
+
+        if (!installedPlugins.includes(p.name)) {
+          installedPlugins.push(p.name);
+        }
       }
     }
   });

--- a/tests/plugin-manager.spec.ts
+++ b/tests/plugin-manager.spec.ts
@@ -2,7 +2,7 @@ import { addDefaultPlugins, addPluginMethods, initPlugins, getInstalledPlugins }
 
 import { DEFAULT_CONFIG } from '../src/constants';
 import { LogDNAMethods } from '../src/LogDNAMethods';
-import { LogDNABrowserOptions, Plugin } from '../src/logdna';
+import { LogDNABrowserOptions, Plugin, LogMessage } from '../src/logdna';
 
 declare module '../src/LogDNAMethods' {
   interface LogDNAMethods {
@@ -22,7 +22,12 @@ const TestPlugin = (): Plugin => ({
   },
   init,
   hooks: {
-    beforeSend: () => {},
+    beforeSend({ level = 'log', message = 'Test' }: LogMessage): LogMessage {
+      return {
+        level,
+        message,
+      };
+    },
   },
 });
 


### PR DESCRIPTION
Summary:
Add correct types to the BeforeSendHook arguments and return data.
Update test to use correct data structure instead of a generic mock.
Also add plugin name to plugins array when the plugin just has a
hook and not an init function
Fixes #29

Semver: patch