### PR TITLE
fix (error): Unhandled promise rejection handler

### DIFF
--- a/src/capture.ts
+++ b/src/capture.ts
@@ -17,10 +17,14 @@ const captureMessage = ({ level = 'log', message, lineContext = {} }: LogMessage
   generateLogLine({ level, message, lineContext });
 };
 
-const captureError = (error: any) => {
+const captureError = (error: any, isUnhandledRejection = false) => {
   if (isSendingDisabled()) return;
 
-  const message = error.name ? `${error.name}: ${error.message}` : error.message;
+  let message = error.name ? `${error.name}: ${error.message}` : error.message;
+
+  if (isUnhandledRejection) {
+    message = `Uncaught (in promise) ${message}`;
+  }
 
   generateLogLine({
     level: 'error',

--- a/src/plugins/global-handler.ts
+++ b/src/plugins/global-handler.ts
@@ -25,30 +25,8 @@ const addUnhandledrejection = () => {
 
 /*  istanbul ignore next */
 const onUnhandledRejection = (e: any) => {
-  let error: any = {};
-  let reason;
-
-  if ('reason' in e) {
-    reason = e.reason;
-  } else if (e && e.detail && e.detail.reason) {
-    reason = e.detail.reason;
-  }
-
-  if (reason instanceof Error) {
-    error = reason;
-  } else if (typeof reason === 'string') {
-    error.message = reason;
-  } else if (e instanceof Error) {
-    error = e;
-  } else if (typeof e === 'string') {
-    error.message = e;
-  } else {
-    error.message = '<unknown>';
-  }
-
-  error.message = `Uncaught (in promise) ${error.message}`;
-
-  captureError(error);
+  let error: any = e.reason;
+  captureError(error, true);
 };
 
 /*  istanbul ignore next */


### PR DESCRIPTION
Cleaner way to handle generating log message from unhandled
promise rejections. Existing test should still pass

Semver: patch