### PR TITLE
fix(ssr): Fix the ability to use the logger with SSR frameworks

### DIFF
--- a/src/capture.ts
+++ b/src/capture.ts
@@ -4,7 +4,7 @@ import { process } from './buffer-manager';
 import utils from './utils';
 import { getStaticContext, getContext, getDynamicContext } from './context-manager';
 import { getSessionId } from './session-manager';
-import { LogMessage, LogDNALogLine } from './logdna';
+import { LogMessage } from './logdna';
 
 const captureMessage = ({ level = 'log', message, lineContext = {} }: LogMessage) => {
   if (isSendingDisabled()) return;

--- a/src/init.ts
+++ b/src/init.ts
@@ -40,6 +40,7 @@ const init = (ingestionKey: string, opts: LogDNABrowserOptions = DEFAULT_CONFIG)
     return;
   }
 
+  utils.cacheConsole();
   sampleRate = utils.generateSampleRateScore();
   initPlugins(options);
   addFlushEvents();


### PR DESCRIPTION
Summary:
A change was introduced that attempted to call `window` during
the browser logger bootstrap, this is fine execpt SSR frameworks
dont have a concept of window during their initial rendering.  This
will now delay caching of the original console instance until after
the logger is enabled.

Semver: patch